### PR TITLE
modify predict step

### DIFF
--- a/model/data_processing1.py
+++ b/model/data_processing1.py
@@ -11,7 +11,6 @@ def map_column(df, col_name):
     mapping = {k: i + 2 for i, k in enumerate(values)}
     inverse_mapping = {v: k for k, v in mapping.items()}
     df[col_name + '_mapped'] = df[col_name].map(mapping)
-    df.drop(df.isnan)
 
     return df, mapping, inverse_mapping
 

--- a/model/model1.py
+++ b/model/model1.py
@@ -69,6 +69,7 @@ class Recommender(pl.LightningModule):
     def training_step(self, batch, batch_idx):
         total_loss = 0
         total_src, total_y_true = batch
+        loss_weight = [0.1, 0.3, 0.6]
         # src_items, y_true = batch
         for _type in range(3):
             src_items = total_src[:, _type, :]
@@ -87,13 +88,14 @@ class Recommender(pl.LightningModule):
 
             self.log('valid_loss', loss)
             self.log('valid_accuracy', accuracy)
-            total_loss += loss
+            total_loss += loss * loss_weight[_type]
 
-        return total_loss / 3
+        return total_loss
 
     def validation_step(self, batch, batch_idx):
         total_loss = 0
         total_src, total_y_true = batch
+        loss_weight = [0.1, 0.3, 0.6]
         # src_items, y_true = batch
         for _type in range(3):
             src_items = total_src[:, _type, :]
@@ -112,13 +114,14 @@ class Recommender(pl.LightningModule):
 
             self.log('valid_loss', loss)
             self.log('valid_accuracy', accuracy)
-            total_loss += loss
+            total_loss += loss * loss_weight[_type]
 
-        return total_loss / 3
+        return total_loss
 
     def test_step(self, batch, batch_idx):
         total_loss = 0
         total_src, total_y_true = batch
+        loss_weight = [0.1, 0.3, 0.6]
         # src_items, y_true = batch
         for _type in range(3):
             src_items = total_src[:, _type, :]
@@ -137,15 +140,16 @@ class Recommender(pl.LightningModule):
 
             self.log('valid_loss', loss)
             self.log('valid_accuracy', accuracy)
-            total_loss += loss
+            total_loss += loss * loss_weight[_type]
 
-        return total_loss / 3
+        return total_loss
 
     def predict_step(self, batch, batch_idx):
-        src_items, _ = batch
+        src_items = batch
         res = []
         for _type in range(3):
-            res.append(self(src_items, _type))
+            reco = self(src_items[_type].unsqueeze(0), _type)
+            res.append(reco)
         return res
 
     def configure_optimizers(self):


### PR DESCRIPTION
## 개요: predict step 수정

### 내용
- test 데이터의 아이템 sequence tensor에 따라 예측값이 내보내질 수 있도록 `predict_step`수정
- 기타 불필요한 코드 수정
- 이 외 학습 간 `loss = R_clicks * 0.1 + R_carts * 0.3 + R_orders * 0.6`에 맞게끔 `loss` 수정
- 일부 상관없는 comment들이 존재하지만 나중에 삭제할 예정
- 현재 데이터는 잘 출력은 되지만 정상적인 아이템 출력은 되지 않는데 조금 더 학습 시키고 최종 submission 만들예정